### PR TITLE
fix(ci): upgrade jenkins-lib-common to 1.6.2 and fix exclusion regex patterns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 library(
-    identifier: 'jenkins-lib-common@1.3.4',
+    identifier: 'jenkins-lib-common@1.6.2',
     retriever: modernSCM([
         $class: 'GitSCMSource',
         credentialsId: 'jenkins-integration-with-github-account',
@@ -50,7 +50,7 @@ pipeline {
                 uploadStage(
                     packages: yapHelper.resolvePackageNames(),
                     exclusions: [
-                        'carbonio-prometheus': ['*alertmanager*.rpm', '*exporter*.rpm']
+                        'carbonio-prometheus': ['.*alertmanager.*\\.rpm', '.*exporter.*\\.rpm']
                     ]
                 )
             }


### PR DESCRIPTION
## Why

`jenkins-lib-common` 1.3.4 switched upload specs to `"regexp": "true"` to fix RPM prefix-name collisions. This mode also applies to the `exclusions` field — JFrog compiles them as Java regex.

The existing exclusion patterns were glob-style (`*alertmanager*.rpm`), which caused the build to fail with:

```
java.util.regex.PatternSyntaxException: Dangling meta character '*' near index 1
(*alertmanager*.rpm)|(*exporter*.rpm)
 ^
```

This broke the Upload stage on the `devel` branch (builds #6 and #7).

## What

- Convert exclusion patterns from glob to valid Java regex:
  - `*alertmanager*.rpm` → `.*alertmanager.*\.rpm`
  - `*exporter*.rpm` → `.*exporter.*\.rpm`
- Bump `jenkins-lib-common` from `1.3.4` to `1.6.2` (latest stable)

## Verified

Fix confirmed via Jenkins Replay on build #6 — upload stage passed with the corrected regex patterns.