### PR TITLE
fix: add make to makedepends and bump yap image to 2.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 # Configuration
 .DEFAULT_GOAL := build
 YAP_IMAGE_PREFIX ?= docker.io/m0rf30/yap
-YAP_VERSION ?= 1.49
+YAP_VERSION ?= 2.4.1
 CONTAINER_RUNTIME ?= $(shell command -v docker >/dev/null 2>&1 && echo docker || echo podman)
 
 # Build directories


### PR DESCRIPTION
## What

- Add `make` to `makedepends` in `packages/prometheus-openldap/PKGBUILD`
- Bump `YAP_VERSION` in `Makefile` from `1.49` to `2.4.1` (latest)

## Why

The `build()` function in the openldap PKGBUILD calls `make build`, but `make` was never declared as a build dependency. The package was never actually built before (no prior CI run touched it), so the missing dep went unnoticed until build #5 which was the first run to include this package.

The yap image version was also stale (1.49 vs latest 2.4.1).