### PR TITLE
fix:ZCT-2060:Remove obsolete chown from postinst

### DIFF
--- a/packages/CHANGELOG.md
+++ b/packages/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 * Fixed the APT dependency declaration to ensure required packages are installed automatically
+* Removed obsolete chown command from the OpenLDAP exporter package postinst that targeted the deprecated configuration directory /etc/carbonio/carbonio-prometheus-openldap-exporter
 
 
 ### [0.14.0] (2026-7-07)

--- a/packages/prometheus-openldap/PKGBUILD
+++ b/packages/prometheus-openldap/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname="carbonio-prometheus-openldap-exporter"
 pkgver="3.0.0"
 upstream_ver="2.0.1"
-pkgrel="1"
+pkgrel="2"
 pkgdesc="OpenLDAP exporter for open-source systems monitoring and alerting toolkit"
 maintainer="Zextras <packages@zextras.com>"
 url="https://zextras.com"
@@ -68,7 +68,6 @@ postinst() {
     fi
   fi
 
-  chown -R carbonio-prometheus:carbonio-prometheus /etc/carbonio/carbonio-prometheus-openldap-exporter
 
   if hash initctl 2>/dev/null; then
     initctl reload-configuration 2>/dev/null || true


### PR DESCRIPTION
Removed the obsolete chown command from the package postinst script that targeted the deprecated OpenLDAP exporter configuration directory.